### PR TITLE
fix active subscribers attempting to reconnect after manual Close

### DIFF
--- a/pkg/amqp/connection.go
+++ b/pkg/amqp/connection.go
@@ -59,12 +59,11 @@ func (c *connectionWrapper) Close() error {
 	defer c.logger.Info("Closed AMQP Pub/Sub", nil)
 
 	c.publishingWg.Wait()
+	c.subscribingWg.Wait()
 
 	if err := c.amqpConnection.Close(); err != nil {
 		c.logger.Error("Connection close error", err, nil)
 	}
-
-	c.subscribingWg.Wait()
 
 	return nil
 }
@@ -128,6 +127,7 @@ func (c *connectionWrapper) handleConnectionClose() {
 		select {
 		case <-c.closing:
 			c.logger.Debug("Stopping handleConnectionClose", nil)
+			c.connected = make(chan struct{})
 			return
 		case err := <-notifyCloseConnection:
 			c.connected = make(chan struct{})


### PR DESCRIPTION
Issue is when you have an active subscribers calling Close would result in errors, for example:
```
{"level":"info","topic":"test","amqp_queue_name":"local-test","amqp_exchange_name":"local","message":"Closing from Subscriber received"}

{"level":"error","topic":"test","amqp_queue_name":"local-test","amqp_exchange_name":"local","error":"Failed to close channel: Exception (504) Reason: \"channel/connection is not open\"",}

{"level":"error","topic":"test","amqp_queue_name":"local-test","amqp_exchange_name":"test", "error":"Failed to open channel: cannot open channel: Exception (504) Reason: \"channel/connection is not open\""}

{"level":"info","topic":"test","amqp_queue_name":"local-test","amqp_exchange_name":"test","message":"Stopped consuming from AMQP channel"}

{"level":"info","message":"Closed AMQP Pub/Sub"}
```

It was caused by 2 reasons: `connected` channel was closed and sometimes processed by `select` before `closing` channel in reconnect loop, second - wait group for subscriptions was called after closing a connection that resulted in double closing of AMQP channel.

Example code:
```
        amqpConfig := amqp.NewDurablePubSubConfig("amqp://guest:guest@127.0.0.1:5672", func(topic string) string {
		return "local-" + topic
	})

	s, err := amqp.NewSubscriber(amqpConfig, watermill.NewStdLogger(true, true))
	require.NoError(t, err)
	go func() {
		msgs, err := s.Subscribe(context.Background(), "test")
		require.NoError(t, err)

		for m := range msgs {
			log.Println(m)
		}
	}()

	time.Sleep(5 * time.Second)

	err = s.Close()
	require.NoError(t, err)

	select {}
```

 