### PR TITLE
feat: Allow subscribers/publishers to reuse a single connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/ThreeDotsLabs/watermill v1.2.0-rc.6
 	github.com/cenkalti/backoff/v3 v3.2.2
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/streadway/amqp v1.0.0
@@ -13,7 +14,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect


### PR DESCRIPTION
A subscriber and publisher may now be created with a shared connection, i.e. multiple subscribers and publishers may use the same connection. New functions are added to allow you to reuse existing connections: NewSubscriberWithConnection and NewPublisherWithConnection. The existing behavior is maintained, i.e. when a connection is not supplied then a new connection is created for the subscriber/publisher (as before), and when the subscriber/publisher is closed then the connection is also closed. If a connection is provided to the subscriber/publisher, then when Close is called on the subscriber/publisher, only the resources of the specific subscriber/publisher are cleaned up. In the case of a subscriber, the subscription message listeners are stopped and all message channels are closed, but the connection is not closed. The client that created the connection is responsible for closing the connection.

closes #182

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>