### PR TITLE
feat: Implement a publisher channel pool

### DIFF
--- a/pkg/amqp/channelprovider.go
+++ b/pkg/amqp/channelprovider.go
@@ -1,0 +1,216 @@
+package amqp
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/pkg/errors"
+	"github.com/streadway/amqp"
+)
+
+type channel interface {
+	AMQPChannel() *amqp.Channel
+	Close() error
+}
+
+type channelProvider interface {
+	Channel() (channel, error)
+	CloseChannel(c channel) error
+	Close()
+}
+
+func newChannelProvider(conn *ConnectionWrapper, poolSize int, logger watermill.LoggerAdapter) (channelProvider, error) {
+	if poolSize == 0 {
+		return &defaultChannelProvider{conn}, nil
+	}
+
+	return newPooledChannelProvider(conn, poolSize, logger)
+}
+
+type pooledChannel struct {
+	logger     watermill.LoggerAdapter
+	conn       *ConnectionWrapper
+	amqpChan   *amqp.Channel
+	closedChan chan *amqp.Error
+}
+
+func newPooledChannel(conn *ConnectionWrapper, logger watermill.LoggerAdapter) (*pooledChannel, error) {
+	c := &pooledChannel{
+		logger,
+		conn,
+		nil,
+		nil,
+	}
+
+	if err := c.openAMQPChannel(); err != nil {
+		return nil, fmt.Errorf("open AMQP channel: %w", err)
+	}
+
+	return c, nil
+}
+
+func (c *pooledChannel) AMQPChannel() *amqp.Channel {
+	return c.amqpChan
+}
+
+func (c *pooledChannel) openAMQPChannel() error {
+	var err error
+
+	c.amqpChan, err = c.conn.amqpConnection.Channel()
+	if err != nil {
+		return fmt.Errorf("create AMQP channel: %w", err)
+	}
+
+	c.closedChan = make(chan *amqp.Error, 1)
+
+	c.amqpChan.NotifyClose(c.closedChan)
+
+	return nil
+}
+
+func (c *pooledChannel) validate() error {
+	select {
+	case e := <-c.closedChan:
+		c.logger.Info("AMQP channel was closed. Opening new channel.", watermill.LogFields{"close-error": e.Error()})
+
+		return c.openAMQPChannel()
+	default:
+		return nil
+	}
+}
+
+func (c *pooledChannel) Close() error {
+	return c.amqpChan.Close()
+}
+
+type channelWrapper struct {
+	*amqp.Channel
+}
+
+func (c *channelWrapper) AMQPChannel() *amqp.Channel {
+	return c.Channel
+}
+
+// defaultChannelProvider simply opens a new channel when Channel() is called and closes the channel
+// when CloseChannel is called.
+type defaultChannelProvider struct {
+	conn *ConnectionWrapper
+}
+
+func (p *defaultChannelProvider) Channel() (channel, error) {
+	amqpChan, err := p.conn.amqpConnection.Channel()
+	if err != nil {
+		return nil, fmt.Errorf("create AMQP channel: %w", err)
+	}
+
+	return &channelWrapper{Channel: amqpChan}, nil
+}
+
+func (p *defaultChannelProvider) CloseChannel(c channel) error {
+	return c.Close()
+}
+
+func (p *defaultChannelProvider) Close() {
+	// Nothing to do.
+}
+
+// pooledChannelProvider maintains a pool of channels which are opened immediately upon creation of the provider.
+// The Channel() function returns an existing channel from the pool. If no channel is available then the caller must
+// wait until a channel is returned to the pool (with the CloseChannel function). Channels in the pool are closed when
+// this provider's Close() function is called.
+// This provider improves performance in high volume systems and also acts as a throttle to prevent the AMQP server from
+// overloading.
+type pooledChannelProvider struct {
+	logger     watermill.LoggerAdapter
+	conn       *ConnectionWrapper
+	channels   []*pooledChannel
+	closed     uint32
+	chanPool   chan *pooledChannel
+	closedChan chan struct{}
+}
+
+func newPooledChannelProvider(conn *ConnectionWrapper, poolSize int, logger watermill.LoggerAdapter) (channelProvider, error) {
+	logger.Info("Creating pooled channel provider", watermill.LogFields{"pool-size": poolSize})
+
+	channels := make([]*pooledChannel, poolSize)
+
+	chanPool := make(chan *pooledChannel, poolSize)
+
+	// Create the channels and add them to the pool.
+
+	for i := 0; i < poolSize; i++ {
+		c, err := newPooledChannel(conn, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		channels[i] = c
+
+		chanPool <- c
+	}
+
+	return &pooledChannelProvider{
+		logger,
+		conn,
+		channels,
+		0,
+		chanPool,
+		make(chan struct{}),
+	}, nil
+}
+
+func (p *pooledChannelProvider) Channel() (channel, error) {
+	if p.isClosed() {
+		return nil, errors.New("channel pool is closed")
+	}
+
+	select {
+	case c := <-p.chanPool:
+		// Ensure that the existing AMQP channel is still open.
+		if err := c.validate(); err != nil {
+			return nil, err
+		}
+
+		return c, nil
+
+	case <-p.closedChan:
+		return nil, errors.New("provider is closed")
+	}
+}
+
+func (p *pooledChannelProvider) CloseChannel(c channel) error {
+	if p.isClosed() {
+		return nil
+	}
+
+	pc, ok := c.(*pooledChannel)
+	if !ok {
+		return errors.New("channel must be of type pooledChannel")
+	}
+
+	p.chanPool <- pc
+
+	return nil
+}
+
+func (p *pooledChannelProvider) Close() {
+	if !atomic.CompareAndSwapUint32(&p.closed, 0, 1) {
+		// Already closed.
+		return
+	}
+
+	close(p.closedChan)
+
+	p.logger.Info("Closing all channels in the pool", watermill.LogFields{"pool-size": len(p.channels)})
+
+	for _, c := range p.channels {
+		if err := c.Close(); err != nil {
+			p.logger.Error("Error closing channel: %s", err, watermill.LogFields{})
+		}
+	}
+}
+
+func (p *pooledChannelProvider) isClosed() bool {
+	return atomic.LoadUint32(&p.closed) != 0
+}

--- a/pkg/amqp/config.go
+++ b/pkg/amqp/config.go
@@ -399,6 +399,14 @@ type PublishConfig struct {
 
 	// With transactional enabled, all messages wil be added in transaction.
 	Transactional bool
+
+	// ChannelPoolSize specifies the size of a channel pool. All channels in the pool are opened when the publisher is
+	// created. When a Publish operation is performed then a channel is taken from the pool to perform the operation and
+	// then returned to the pool once the operation has finished. If all channels are in use then the Publish operation
+	// waits until a channel is returned to the pool.
+	// If this value is set to 0 (default) then channels are not pooled and a new channel is opened/closed for every
+	// Publish operation.
+	ChannelPoolSize int
 }
 
 type ConsumeConfig struct {


### PR DESCRIPTION
A new Publisher configuration parameter was added: ChannelPoolSize. If this parameter is set to 0 (default) then there is no change to the existing behavior, i.e. a channel is opened/closed for every Publish operation. If this parameter is set to a value greater than 0 then a channel pool is maintained, where channels are reused. The number of channels for a publisher will not exceed the value of this parameter, i.e. if the Publish function is invoked and there are no available channels in the pool then the caller will wait.

The channel pool improves performance in high volume systems by not incurring the overhead of opening and closing channels, and the pool also acts as a throttle to prevent the AMQP server from overloading.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>