### PR TITLE
fix: Deadlock in subscriber consuming loop

### DIFF
--- a/pkg/amqp/subscriber.go
+++ b/pkg/amqp/subscriber.go
@@ -238,7 +238,7 @@ func (s *Subscriber) runSubscriber(
 		}
 	}()
 
-	notifyCloseChannel := channel.NotifyClose(make(chan *amqp.Error))
+	notifyCloseChannel := channel.NotifyClose(make(chan *amqp.Error, 1))
 
 	sub := subscription{
 		out:                out,


### PR DESCRIPTION
When an AMQP server is restarted then the subscriber channels are closed and 'NotifyClose' handlers are notified. Currently the Go channel registered with the AMQP channel has no buffer and this intermittently causes a deadlock. For example, if an error occurs while processing a message in the ConsumingLoop then the function exits, so when the AMQP channel attempts to send an error to the Go channel when it is being shut down, there are no consumers and a deadlock occurs. The deadlock is prevented by adding a buffer to the Go channel.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>