### PR TITLE
Delivery confirmation of published messages

### DIFF
--- a/pkg/amqp/config.go
+++ b/pkg/amqp/config.go
@@ -407,6 +407,11 @@ type PublishConfig struct {
 	// If this value is set to 0 (default) then channels are not pooled and a new channel is opened/closed for every
 	// Publish operation.
 	ChannelPoolSize int
+
+	// ConfirmDelivery indicates whether the Publish function should wait until a confirmation is received from
+	// the AMQP server in order to guarantee that the message is delivered. Setting this value to true may
+	// negatively impact performance but will increase reliability.
+	ConfirmDelivery bool
 }
 
 type ConsumeConfig struct {

--- a/pkg/amqp/pubsub_test.go
+++ b/pkg/amqp/pubsub_test.go
@@ -32,6 +32,17 @@ func createPubSub(t *testing.T) (message.Publisher, message.Subscriber) {
 	return createPubSubWithConfig(t, publisherCfg)
 }
 
+func createPubSubWithDeliveryConfirmation(t *testing.T) (message.Publisher, message.Subscriber) {
+	publisherCfg := amqp.NewDurablePubSubConfig(
+		amqpURI(),
+		nil,
+	)
+
+	publisherCfg.Publish.ConfirmDelivery = true
+
+	return createPubSubWithConfig(t, publisherCfg)
+}
+
 func createPubSubWithPublisherChannelPool(t *testing.T) (message.Publisher, message.Subscriber) {
 	publisherCfg := amqp.NewDurablePubSubConfig(
 		amqpURI(),
@@ -39,6 +50,18 @@ func createPubSubWithPublisherChannelPool(t *testing.T) (message.Publisher, mess
 	)
 
 	publisherCfg.Publish.ChannelPoolSize = 50
+
+	return createPubSubWithConfig(t, publisherCfg)
+}
+
+func createPubSubWithPublisherChannelPoolAndDeliveryConfirmation(t *testing.T) (message.Publisher, message.Subscriber) {
+	publisherCfg := amqp.NewDurablePubSubConfig(
+		amqpURI(),
+		nil,
+	)
+
+	publisherCfg.Publish.ChannelPoolSize = 50
+	publisherCfg.Publish.ConfirmDelivery = true
 
 	return createPubSubWithConfig(t, publisherCfg)
 }
@@ -121,6 +144,21 @@ func TestPublishSubscribe_pubsub(t *testing.T) {
 	)
 }
 
+func TestPublishSubscribe_pubsub_delivery_confirmation(t *testing.T) {
+	tests.TestPubSub(
+		t,
+		tests.Features{
+			ConsumerGroups:                      true,
+			ExactlyOnceDelivery:                 false,
+			GuaranteedOrder:                     true,
+			GuaranteedOrderWithSingleSubscriber: true,
+			Persistent:                          true,
+		},
+		createPubSubWithDeliveryConfirmation,
+		createPubSubWithConsumerGroup,
+	)
+}
+
 func TestPublishSubscribe_pubsub_with_channel_pool(t *testing.T) {
 	tests.TestPubSub(
 		t,
@@ -132,6 +170,21 @@ func TestPublishSubscribe_pubsub_with_channel_pool(t *testing.T) {
 			Persistent:                          true,
 		},
 		createPubSubWithPublisherChannelPool,
+		createPubSubWithConsumerGroup,
+	)
+}
+
+func TestPublishSubscribe_pubsub_with_channel_pool_and_delivery_confirmation(t *testing.T) {
+	tests.TestPubSub(
+		t,
+		tests.Features{
+			ConsumerGroups:                      true,
+			ExactlyOnceDelivery:                 false,
+			GuaranteedOrder:                     true,
+			GuaranteedOrderWithSingleSubscriber: true,
+			Persistent:                          true,
+		},
+		createPubSubWithPublisherChannelPoolAndDeliveryConfirmation,
 		createPubSubWithConsumerGroup,
 	)
 }


### PR DESCRIPTION
This commit adds a flag to the publish config that turns on delivery confirmation. If set to true then the Publish function waits until a confirmation is received from the AMQP server to guarantee that the message is delivered. By default, delivery of published messages is not confirmed.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>