### PR TITLE
fix: Adjust notifyCloseConnection to be a buffered channel to avoid blocking during exception handling

### DIFF
--- a/pkg/amqp/connection.go
+++ b/pkg/amqp/connection.go
@@ -128,7 +128,7 @@ func (c *ConnectionWrapper) handleConnectionClose() {
 		<-c.connected
 		c.logger.Debug("handleConnectionClose is for connection or Pub/Sub close", nil)
 
-		notifyCloseConnection := c.amqpConnection.NotifyClose(make(chan *amqp.Error))
+		notifyCloseConnection := c.amqpConnection.NotifyClose(make(chan *amqp.Error, 1))
 
 		select {
 		case <-c.closing:


### PR DESCRIPTION
When closing the connection, an EOF error in the read method may trigger the shutdown operation. If notifyCloseConnection is unbuffered at this time, it will block graceful shutdown.