### PR TITLE
fix: error message paths in config.go

### DIFF
--- a/pkg/amqp/config.go
+++ b/pkg/amqp/config.go
@@ -340,7 +340,7 @@ type ConnectionConfig struct {
 	Reconnect *ReconnectConfig
 }
 
-// QueueNameGenerator generates QueueName based on the topic.
+// ExchangeNameGenerator generates ExchangeName based on the topic.
 type ExchangeNameGenerator func(topic string) string
 
 // GenerateExchangeNameTopicName generates exchangeName equal to the topic.

--- a/pkg/amqp/config.go
+++ b/pkg/amqp/config.go
@@ -282,14 +282,14 @@ func (c Config) validate(validateConnection bool) error {
 
 	if validateConnection {
 		if c.Connection.AmqpURI == "" {
-			err = multierror.Append(err, errors.New("empty Config.AmqpURI"))
+			err = multierror.Append(err, errors.New("empty Config.Connection.AmqpURI"))
 		}
 	}
 	if c.Marshaler == nil {
 		err = multierror.Append(err, errors.New("missing Config.Marshaler"))
 	}
 	if c.Exchange.GenerateName == nil {
-		err = multierror.Append(err, errors.New("missing Config.GenerateName"))
+		err = multierror.Append(err, errors.New("missing Config.Exchange.GenerateName"))
 	}
 
 	return err
@@ -299,7 +299,7 @@ func (c Config) validatePublisher(validateConnection bool) error {
 	err := c.validate(validateConnection)
 
 	if c.Publish.GenerateRoutingKey == nil {
-		err = multierror.Append(err, errors.New("missing Config.GenerateRoutingKey"))
+		err = multierror.Append(err, errors.New("missing Config.Publish.GenerateRoutingKey"))
 	}
 
 	return err


### PR DESCRIPTION
<!--
Thanks for contributing to Watermill!

The following template aims to help contributors write a good description for their pull requests.
**The more information you provide, the faster we will be able to review and merge your PR.**

Feel free to skip this template for minor changes like typo fixes.

-->

### Motivation / Background

<!--

Explain the purpose of this Pull Request:
- What issue or bug does it address?
- What new functionality does it add?
- Why are these changes needed?
For bug fixes, include "Fixes #ISSUE" to automatically link to the related issue.

-->
The error messages for missing config values is misleading. An example is if you don't include set `Config.Exchange.GenerateName` the error message states: `missing Config.GenerateName`.

This also fixes the docstring for `ExchangeNameGenerator` which before was a copy of the `QueueNameGenerator` docstring.

These changes will make the package easier to use and debug.

### Details

<!-- Describe how you solved the problem or implemented the feature. -->
I updated the paths in error messages to be correct.

### Alternative approaches considered (if applicable)

<!-- If applicable, describe alternative approaches you considered and why you chose this one. -->

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [ ] I wrote tests for the changes.
- [x] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [ ] Code has no breaking changes. [I'm not sure if these are considered breaking changes]
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).
