### PR TITLE
Inject raw Delivery.Redelivered in message.Message to deduce duplicate message

### DIFF
--- a/pkg/amqp/subscriber.go
+++ b/pkg/amqp/subscriber.go
@@ -400,6 +400,12 @@ func (s *subscription) processMessage(
 	msgLogFields := logFields.Add(watermill.LogFields{"message_uuid": msg.UUID})
 	s.logger.Trace("Unmarshaled message", msgLogFields)
 
+	// Redelivered flag is set to true when the message is redelivered.
+	if amqpMsg.Redelivered {
+		msg.Metadata.Set("redeliverd", "true")
+		s.logger.Trace("Message redelivered", msgLogFields)
+	}
+
 	select {
 	case <-s.closing:
 		s.logger.Info("Message not consumed, pub/sub is closing", msgLogFields)


### PR DESCRIPTION
<!--
Thanks for contributing to Watermill!

The following template aims to help contributors write a good description for their pull requests.
**The more information you provide, the faster we will be able to review and merge your PR.**

Feel free to skip this template for minor changes like typo fixes.

-->

### Motivation / Background

<!--

Explain the purpose of this Pull Request:
- What issue or bug does it address?
- What new functionality does it add?
- Why are these changes needed?
For bug fixes, include "Fixes #ISSUE" to automatically link to the related issue.

-->
### Problem: Redelivered Flag Not Exposed 
#### Issue: https://github.com/ThreeDotsLabs/watermill/issues/554

According to the RabbitMQ [reliability docs](https://www.rabbitmq.com/docs/reliability#consumer-side), messages may be [redelivered](https://www.rabbitmq.com/docs/consumers#message-properties) in the event of network or node failures. RabbitMQ sets the `redelivered` flag to indicate that a message may have been previously delivered. If this flag is not set, the message is guaranteed to be new.

Currently, Watermill’s AMQP subscriber does not expose this `redelivered` flag in the message metadata.

### Real-World Impact

While chaos testing our application using Watermill’s AMQP library, we encountered a scenario where message duplication occurred after a sudden connection failure. Specifically:

- A message was processed and published to a downstream queue.
- During this process, the connection was disrupted.
- The consumer’s nack was lost, triggering a redelivery from RabbitMQ.
- Since the `redelivered` flag wasn’t accessible, our system couldn’t differentiate a first-time delivery from a retry.

We initially implemented deduplication based on message IDs, but it's inefficient. As recommended in [RabbitMQ's documentation](https://www.rabbitmq.com/docs/confirms#automatic-requeueing), leveraging the `redelivered` flag allows more efficient handling of duplicate processing.

### Sample Scenario from Logs

1. Message `5288c6a32394` is consumed from the **Source** queue and being published to the **Target** queue.
2. The connection drops mid-process.
3. Upon reconnection, the message reaches the **Target** queue.
4. RabbitMQ redelivers the same message to the **Source** due to the lost nack.

---

### Proposal

Expose the `redelivered` flag in `message.Metadata` with a key like `amqp_redelivered`, allowing consumers to implement more efficient and reliable deduplication logic.

Let me know if you want the corresponding test case to go with it!

### Details

<!-- Describe how you solved the problem or implemented the feature. -->

We can include the `Redelivered` boolean flag from the `Delivery` struct in message metadata, this helps to reduce deduplication effort by concentrating checks for messages which have this metadata value pre-set. 
https://github.com/rabbitmq/amqp091-go/blob/main/delivery.go?plain=1#L54

#### Without change: 
```console
2025-04-15T11:53:14+05:30 ERROR /home/skar/queue/producer.go:82 Error publishing the message to queue topic Target: failed to publish message: not connected to AMQP error="failed to publish message: not connected to AMQP"
2025-04-15T11:53:14+05:30 INFO /home/skar/queue/producer.go:84 Retrying to publish the message #######-####-####-####-5288c6a32394 to queue: Target
2025-04-15T11:53:14+05:30 WARN /home/skar/queue/producer.go:66 Retrying operation in few seconds

2025-04-15T11:53:27+05:30 INFO /home/skar/queue/logger.go:33 Connected to AMQP
2025-04-15T11:53:32+05:30 INFO /home/skar/queue/logger.go:33 Connected to AMQP
2025-04-15T11:53:32+05:30 INFO /home/skar/queue/logger.go:31 Starting consuming from AMQP channel
2025-04-15T11:53:33+05:30 INFO /home/skar/queue/logger.go:33 Connected to AMQP
2025-04-15T11:53:34+05:30 INFO /home/skar/queue/logger.go:33 Connected to AMQP
2025-04-15T11:53:36+05:30 INFO /home/skar/queue/logger.go:33 Connected to AMQP
2025-04-15T11:53:41+05:30 INFO /home/skar/queue/logger.go:33 Connected to AMQP
2025-04-15T11:53:41+05:30 INFO /home/skar/queue/logger.go:31 Starting consuming from AMQP channel

2025-04-15T11:54:18+05:30 INFO /home/skar/queue/queue.go:221 Published message to topic: Target, message: "REDACTED" [amqps://REDACTED:REDACTED@localhost:5673] [#######-####-####-####-5288c6a32394] [amqp]
2025-04-15T11:54:18+05:30 INFO /home/skar/queue/producer.go:90 Successfully published the message to queue topic Target
2025-04-15T11:54:18+05:30 INFO /home/skar/queue/queue.go:174 Received message #######-####-####-####-5288c6a32394 on topic: Target
2025-04-15T11:54:18+05:30 ERROR /home/skar/queue/logger.go:22 Processing message failed, sending nack error="Exception (504) Reason: \"channel/connection is not open\""
2025-04-15T11:54:18+05:30 ERROR /home/skar/queue/logger.go:22 Cannot nack message error="Exception (504) Reason: \"channel/connection is not open\""
2025-04-15T11:54:18+05:30 INFO /home/skar/systems/manager/writer.go:119 Message #######-####-####-####-5288c6a32394 written to database
2025-04-15T11:54:19+05:30 INFO /home/skar/queue/logger.go:31 Starting consuming from AMQP channel
2025-04-15T11:54:19+05:30 INFO /home/skar/queue/queue.go:174 Received message #######-####-####-####-5288c6a32394 on topic: Source
```
#### With proposed change:
```console
2025-04-15T11:54:31+05:30 INFO /home/skar/queue/logger.go:31 Starting consuming from AMQP channel
2025-04-15T11:54:31+05:30 INFO /home/skar/queue/queue.go:174 Received message #######-####-####-####-17716f5cc088 on topic: Source
2025-04-15T11:54:31+05:30 WARN /home/skar/queue/queue.go:177 Message #######-####-####-####-17716f5cc088 is redelivered, ignoring
```

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [ ] I wrote tests for the changes.
- [x] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [x] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).
