### PR TITLE
fix: skip non-string AMQP headers instead of returning error

### DIFF
--- a/pkg/amqp/correlatingmarshaler.go
+++ b/pkg/amqp/correlatingmarshaler.go
@@ -59,11 +59,12 @@ func (cm CorrelatingMarshaler) Unmarshal(amqpMsg amqp.Delivery) (*message.Messag
 	msg.Metadata = make(message.Metadata)
 
 	for key, value := range amqpMsg.Headers {
-		var ok bool
-		msg.Metadata[key], ok = value.(string)
+		valueStr, ok := value.(string)
 		if !ok {
-			return nil, errors.Errorf("metadata %s is not a string, but %#v", key, value)
+			// skipping non-string header (e.g., x-death from dead letter queues)
+			continue
 		}
+		msg.Metadata[key] = valueStr
 	}
 
 	return msg, nil

--- a/pkg/amqp/correlatingmarshaler_test.go
+++ b/pkg/amqp/correlatingmarshaler_test.go
@@ -110,3 +110,39 @@ func BenchmarkCorrelatingMarshaler_Unmarshal(b *testing.B) {
 
 	assert.NoError(b, err)
 }
+
+func TestCorrelatingMarshaler_non_string_headers(t *testing.T) {
+	marshaler := amqp.CorrelatingMarshaler{}
+
+	msg := message.NewMessage(watermill.NewUUID(), []byte("payload"))
+	msg.Metadata.Set("foo", "bar")
+
+	marshaled, err := marshaler.Marshal(msg)
+	require.NoError(t, err)
+
+	// Simulate non-string headers added by RabbitMQ (e.g., x-death from dead letter queues)
+	delivery := publishingToDelivery(marshaled)
+	delivery.Headers["x-death"] = []interface{}{
+		map[string]interface{}{
+			"queue":     "my-queue",
+			"reason":    "rejected",
+			"count":     1,
+			"time":      "2024-01-01T00:00:00Z",
+			"exchange":  "",
+			"routing-keys": []string{"my-routing-key"},
+		},
+	}
+	delivery.Headers["x-array"] = []string{"a", "b", "c"}
+	delivery.Headers["x-int"] = 42
+
+	unmarshaledMsg, err := marshaler.Unmarshal(delivery)
+	require.NoError(t, err)
+
+	// String headers should still be preserved
+	assert.Equal(t, "bar", unmarshaledMsg.Metadata.Get("foo"))
+
+	// Non-string headers should be skipped (not cause an error)
+	assert.Empty(t, unmarshaledMsg.Metadata.Get("x-death"))
+	assert.Empty(t, unmarshaledMsg.Metadata.Get("x-array"))
+	assert.Empty(t, unmarshaledMsg.Metadata.Get("x-int"))
+}

--- a/pkg/amqp/marshaler.go
+++ b/pkg/amqp/marshaler.go
@@ -84,11 +84,12 @@ func (d DefaultMarshaler) Unmarshal(amqpMsg amqp.Delivery) (*message.Message, er
 			continue
 		}
 
-		var ok bool
-		msg.Metadata[key], ok = value.(string)
+		valueStr, ok := value.(string)
 		if !ok {
-			return nil, errors.Errorf("metadata %s is not a string, but %#v", key, value)
+			// skipping non-string header (e.g., x-death from dead letter queues)
+			continue
 		}
+		msg.Metadata[key] = valueStr
 	}
 
 	return msg, nil

--- a/pkg/amqp/marshaler_test.go
+++ b/pkg/amqp/marshaler_test.go
@@ -133,6 +133,42 @@ func BenchmarkDefaultMarshaler_Unmarshal(b *testing.B) {
 	assert.NoError(b, err)
 }
 
+func TestDefaultMarshaler_non_string_headers(t *testing.T) {
+	marshaler := amqp.DefaultMarshaler{}
+
+	msg := message.NewMessage(watermill.NewUUID(), []byte("payload"))
+	msg.Metadata.Set("foo", "bar")
+
+	marshaled, err := marshaler.Marshal(msg)
+	require.NoError(t, err)
+
+	// Simulate non-string headers added by RabbitMQ (e.g., x-death from dead letter queues)
+	delivery := publishingToDelivery(marshaled)
+	delivery.Headers["x-death"] = []interface{}{
+		map[string]interface{}{
+			"queue":     "my-queue",
+			"reason":    "rejected",
+			"count":     1,
+			"time":      "2024-01-01T00:00:00Z",
+			"exchange":  "",
+			"routing-keys": []string{"my-routing-key"},
+		},
+	}
+	delivery.Headers["x-array"] = []string{"a", "b", "c"}
+	delivery.Headers["x-int"] = 42
+
+	unmarshaledMsg, err := marshaler.Unmarshal(delivery)
+	require.NoError(t, err)
+
+	// String headers should still be preserved
+	assert.Equal(t, "bar", unmarshaledMsg.Metadata.Get("foo"))
+
+	// Non-string headers should be skipped (not cause an error)
+	assert.Empty(t, unmarshaledMsg.Metadata.Get("x-death"))
+	assert.Empty(t, unmarshaledMsg.Metadata.Get("x-array"))
+	assert.Empty(t, unmarshaledMsg.Metadata.Get("x-int"))
+}
+
 func publishingToDelivery(marshaled stdAmqp.Publishing) stdAmqp.Delivery {
 	return stdAmqp.Delivery{
 		Body:          marshaled.Body,


### PR DESCRIPTION
Fixes ThreeDotsLabs/watermill#65

## Summary
When receiving AMQP messages with non-string headers (such as \`x-death\` from dead letter queues), the marshaler now skips these headers instead of returning an error. This allows processing of messages that have been through dead letter queues.

## Changes
- Modified \`DefaultMarshaler.Unmarshal\` to skip non-string headers instead of returning an error
- Modified \`CorrelatingMarshaler.Unmarshal\` with the same fix
- Added tests for both marshalers to verify non-string headers are skipped without error

## Testing
- Added \`TestDefaultMarshaler_non_string_headers\` test case
- Added \`TestCorrelatingMarshaler_non_string_headers\` test case

## Diff Stats
\`\`\`
 pkg/amqp/correlatingmarshaler.go      |  7 +++---
 pkg/amqp/correlatingmarshaler_test.go | 35 ++++++++++++++++++++++++++++
 pkg/amqp/marshaler.go                 |  7 +++---
 pkg/amqp/marshaler_test.go            | 35 ++++++++++++++++++++++++++++
 4 files changed, 80 insertions(+), 6 deletions(-)
\`\`\`